### PR TITLE
Provide a way to get user roles from external REST endpoint

### DIFF
--- a/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/AuthorizationProperties.java
+++ b/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/AuthorizationProperties.java
@@ -24,10 +24,13 @@ import java.util.List;
  * @author Eric Bottard
  * @author Gunnar Hillert
  * @author Ilayaperumal Gopinathan
+ * @author Mike Heath
  */
 public class AuthorizationProperties {
 
 	private boolean enabled = true;
+
+	private String externalAuthoritiesUrl;
 
 	private List<String> rules = new ArrayList<>();
 
@@ -59,6 +62,14 @@ public class AuthorizationProperties {
 
 	public void setEnabled(boolean enabled) {
 		this.enabled = enabled;
+	}
+
+	public String getExternalAuthoritiesUrl() {
+		return externalAuthoritiesUrl;
+	}
+
+	public void setExternalAuthoritiesUrl(String externalAuthoritiesUrl) {
+		this.externalAuthoritiesUrl = externalAuthoritiesUrl;
 	}
 
 	public String getDashboardUrl() {
@@ -116,5 +127,4 @@ public class AuthorizationProperties {
 	public void setAuthenticatedPaths(List<String> authenticatedPaths) {
 		this.authenticatedPaths = authenticatedPaths;
 	}
-
 }

--- a/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/support/ExternalOauth2ResourceAuthoritiesExtractor.java
+++ b/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/support/ExternalOauth2ResourceAuthoritiesExtractor.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.common.security.support;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.boot.autoconfigure.security.oauth2.resource.AuthoritiesExtractor;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.OAuth2RestTemplate;
+import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.util.StringUtils;
+
+/**
+ * Spring Cloud {@link AuthoritiesExtractor} that looks up
+ * {@link CoreSecurityRoles} from an external HTTP resource. Requests to the
+ * external HTTP resource are authenticated by forwarding the user's access
+ * token. The external resource's response body MUST be a JSON array
+ * containing strings with values corresponding to
+ * {@link CoreSecurityRoles#key} values. For example, a response containing
+ * {@code ["VIEW", "CREATE"]} would grant the user
+ * {@code ROLE_VIEW, ROLE_CREATE},
+ *
+ * @author Mike Heath
+ */
+public class ExternalOauth2ResourceAuthoritiesExtractor implements AuthoritiesExtractor {
+
+	private static final Logger logger = LoggerFactory.getLogger(ExternalOauth2ResourceAuthoritiesExtractor.class);
+
+	public static final GrantedAuthority CREATE = new SimpleGrantedAuthority(SecurityConfigUtils.ROLE_PREFIX + CoreSecurityRoles.CREATE.getKey());
+	public static final GrantedAuthority MANAGE = new SimpleGrantedAuthority(SecurityConfigUtils.ROLE_PREFIX + CoreSecurityRoles.MANAGE.getKey());
+	public static final GrantedAuthority VIEW = new SimpleGrantedAuthority(SecurityConfigUtils.ROLE_PREFIX + CoreSecurityRoles.VIEW.getKey());
+
+	private final OAuth2RestTemplate restTemplate;
+	private final URI roleProviderUri;
+
+	/**
+	 *
+	 * @param restTemplate used for acquiring the user's access token and
+	 *                     requesting the user's security roles
+	 * @param roleProviderUri a HTTP GET request is sent to this URI to fetch
+	 *                        the user's security roles
+	 */
+	public ExternalOauth2ResourceAuthoritiesExtractor(OAuth2RestTemplate restTemplate, URI roleProviderUri) {
+		this.restTemplate = restTemplate;
+		this.roleProviderUri = roleProviderUri;
+	}
+
+	@Override
+	public List<GrantedAuthority> extractAuthorities(Map<String, Object> map) {
+		logger.debug("Getting permissions from {}", roleProviderUri);
+		final OAuth2AccessToken token = restTemplate.getAccessToken();
+		RequestEntity<?> request = RequestEntity.get(roleProviderUri)
+				.header("Authorization", "bearer " + token.getValue()).build();
+		final ResponseEntity<String[]> entity = restTemplate.exchange(request, String[].class);
+
+		final List<GrantedAuthority> authorities = new ArrayList<>();
+		for (String permission : entity.getBody()) {
+			if (StringUtils.isEmpty(permission)) {
+				logger.warn("Received an empty permission from {}", roleProviderUri);
+			} else {
+				final CoreSecurityRoles securityRole = CoreSecurityRoles.fromKey(permission.toUpperCase());
+				if (securityRole == null) {
+					logger.warn("Invalid role {} provided by {}", permission, roleProviderUri);
+				} else {
+					switch (securityRole) {
+						case CREATE:
+							authorities.add(CREATE);
+							break;
+						case MANAGE:
+							authorities.add(MANAGE);
+							break;
+						case VIEW:
+							authorities.add(VIEW);
+							break;
+					}
+				}
+			}
+		}
+		logger.info("Roles {} add for user {}", authorities, map);
+		return authorities;
+	}
+}
+

--- a/spring-cloud-common-security-config-web/src/test/java/org/springframework/cloud/common/security/support/ExternalOauth2ResourceAuthoritiesExtractorTests.java
+++ b/spring-cloud-common-security-config-web/src/test/java/org/springframework/cloud/common/security/support/ExternalOauth2ResourceAuthoritiesExtractorTests.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */package org.springframework.cloud.common.security.support;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.OAuth2RestTemplate;
+import org.springframework.security.oauth2.common.DefaultOAuth2AccessToken;
+import org.springframework.security.oauth2.common.OAuth2AccessToken;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Mike Heath
+ */
+public class ExternalOauth2ResourceAuthoritiesExtractorTests {
+
+	@Test
+	public void testExtractAuthorities() {
+		assertAuthorities(URI.create("http://test/authorities"), "VIEW");
+		assertAuthorities(URI.create("http://the.authorities.server/authorities"), "VIEW", "CREATE", "MANAGE");
+		assertAuthorities(URI.create("http://server/"), "MANAGE");
+	}
+
+	private void assertAuthorities(URI uri, String... roles) {
+		final OAuth2RestTemplate mockRestTemplate = mock(OAuth2RestTemplate.class);
+		final String accessToken = UUID.randomUUID().toString();
+		final OAuth2AccessToken oAuth2AccessToken = new DefaultOAuth2AccessToken(accessToken);
+		final ArgumentCaptor<RequestEntity> requestArgumentCaptor = ArgumentCaptor.forClass(RequestEntity.class);
+		when(mockRestTemplate.getAccessToken()).thenReturn(oAuth2AccessToken);
+		when(mockRestTemplate.exchange(requestArgumentCaptor.capture(), (Class<String[]>)any())).thenReturn(new ResponseEntity<>(roles, HttpStatus.OK));
+
+		final ExternalOauth2ResourceAuthoritiesExtractor authoritiesExtractor =
+				new ExternalOauth2ResourceAuthoritiesExtractor(mockRestTemplate, uri);
+		final List<GrantedAuthority> grantedAuthorities = authoritiesExtractor.extractAuthorities(new HashMap<>());
+		for (String role : roles) {
+			assertThat(grantedAuthorities, hasItem(new SimpleGrantedAuthority(SecurityConfigUtils.ROLE_PREFIX + role)));
+		}
+
+		verify(mockRestTemplate).exchange(requestArgumentCaptor.capture(), (Class<String[]>)any());
+		final RequestEntity requestEntity = requestArgumentCaptor.getValue();
+		assertThat(requestEntity.getUrl(), equalTo(uri));
+		assertThat(requestEntity.getMethod(), equalTo(HttpMethod.GET));
+		assertThat(requestEntity.getHeaders().get("Authorization"), contains("bearer " + accessToken));
+
+	}
+}


### PR DESCRIPTION
This provides a way of getting the user's roles from an external REST
endpoint. This is needed for SCDF for PCF so that we can determine the
user's roles based off of whether or not the user has access to the
Cloud Foundry SCDF service instance.