### PR TITLE
Remove explicit use of @EnableWebSecurity

### DIFF
--- a/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/BasicAuthSecurityConfiguration.java
+++ b/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/BasicAuthSecurityConfiguration.java
@@ -18,7 +18,6 @@ package org.springframework.cloud.common.security;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.security.SecurityProperties;
 import org.springframework.cloud.common.security.support.OnSecurityEnabledAndOAuth2Disabled;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
@@ -27,7 +26,6 @@ import org.springframework.http.MediaType;
 import org.springframework.cloud.common.security.support.SecurityConfigUtils;
 import org.springframework.cloud.common.security.support.SecurityStateBean;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.annotation.web.configurers.ExpressionUrlAuthorizationConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -59,7 +57,6 @@ import org.springframework.web.accept.ContentNegotiationStrategy;
  */
 @Configuration
 @Conditional(OnSecurityEnabledAndOAuth2Disabled.class)
-@EnableWebSecurity
 public class BasicAuthSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
 	@Autowired

--- a/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/OAuthSecurityConfiguration.java
+++ b/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/OAuthSecurityConfiguration.java
@@ -45,7 +45,6 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.annotation.web.configurers.ExpressionUrlAuthorizationConfigurer;
 import org.springframework.security.oauth2.client.OAuth2ClientContext;
@@ -74,7 +73,6 @@ import org.springframework.web.context.request.NativeWebRequest;
  * @author Ilayaperumal Gopinathan
  */
 @EnableOAuth2Client
-@EnableWebSecurity
 @Configuration
 @Conditional(OnSecurityEnabledAndOAuth2Enabled.class)
 public class OAuthSecurityConfiguration extends WebSecurityConfigurerAdapter {

--- a/spring-cloud-common-security-config-web/src/test/java/org/springframework/cloud/common/security/configtests/ImportConfigsTests.java
+++ b/spring-cloud-common-security-config-web/src/test/java/org/springframework/cloud/common/security/configtests/ImportConfigsTests.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.common.security.configtests;
+
+import org.junit.Test;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.common.security.AuthorizationProperties;
+import org.springframework.cloud.common.security.BasicAuthSecurityConfiguration;
+import org.springframework.cloud.common.security.support.SecurityStateBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+
+public class ImportConfigsTests {
+
+	@Test
+	public void importBasicAuthSecurityConfigurationTest() {
+		SpringApplication app = new SpringApplication(Config.class);
+		app.run();
+	}
+
+	@Import({ BasicAuthSecurityConfiguration.class })
+	@SpringBootApplication
+	public static class Config {
+
+		@Bean
+		public SecurityStateBean securityStateBean() {
+			return new SecurityStateBean();
+		}
+
+		@Bean
+		public AuthorizationProperties authorizationProperties() {
+			return new AuthorizationProperties();
+		}
+	}
+}


### PR DESCRIPTION
- One new test shows trouble with using that annotation.
- We most likely need to come back to this but something
  is a bit wrong with ordering depending where that
  annotation is used. Looks like it's more reliable
  if allowing boot to add it as things start to fail
  if used in config level, however putting annotation
  in main class doesn't cause issues.
- Relates to #13