### PR TITLE
Expose authenticationManagerBean as bean

### DIFF
--- a/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/BasicAuthSecurityConfiguration.java
+++ b/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/BasicAuthSecurityConfiguration.java
@@ -25,6 +25,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.MediaType;
 import org.springframework.cloud.common.security.support.SecurityConfigUtils;
 import org.springframework.cloud.common.security.support.SecurityStateBean;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.annotation.web.configurers.ExpressionUrlAuthorizationConfigurer;
@@ -71,6 +72,12 @@ public class BasicAuthSecurityConfiguration extends WebSecurityConfigurerAdapter
 	@Bean
 	public SessionRepository<? extends Session> sessionRepository() {
 		return new MapSessionRepository(new ConcurrentHashMap<>());
+	}
+
+	@Bean
+	@Override
+	public AuthenticationManager authenticationManagerBean() throws Exception {
+		return super.authenticationManagerBean();
 	}
 
 	@Override


### PR DESCRIPTION
- As authenticationManager is expected in dataflow, expose
  it as documented in boot's migration guide.
- Relates to #13