### PR TITLE
Update Boot + Spring Security Oauth2 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.5.9.RELEASE</version>
+        <version>1.5.16.RELEASE</version>
     </parent>
 
     <modules>

--- a/spring-cloud-common-security-config-web/pom.xml
+++ b/spring-cloud-common-security-config-web/pom.xml
@@ -63,6 +63,7 @@
         <dependency>
             <groupId>org.springframework.security.oauth</groupId>
             <artifactId>spring-security-oauth2</artifactId>
+            <version>2.3.4.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.session</groupId>


### PR DESCRIPTION
- Update Spring Boot version to `1.5.16.RELEASE`
- Explicitly override managed version of `spring-security-oauth2` to `2.3.4.RELEASE`