### PR TITLE
gh-33 Validate scope of the OAuth token

### DIFF
--- a/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/ManualOAuthAuthenticationProvider.java
+++ b/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/ManualOAuthAuthenticationProvider.java
@@ -37,6 +37,7 @@ import org.springframework.security.oauth2.client.token.grant.password.ResourceO
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
 import org.springframework.security.oauth2.common.exceptions.OAuth2Exception;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.security.oauth2.provider.token.ResourceServerTokenServices;
 import org.springframework.web.client.ResourceAccessException;
 
 /**
@@ -55,12 +56,14 @@ public class ManualOAuthAuthenticationProvider implements AuthenticationProvider
 	@Value("${security.oauth2.client.access-token-uri}")
 	private String accessTokenUri;
 
-	@Autowired
-	private UserInfoTokenServices userInfoTokenServices;
+	private final ResourceServerTokenServices resourceServerTokenServices;
 	private final OAuth2ClientContext oauth2ClientContext;
 
-	public ManualOAuthAuthenticationProvider(OAuth2ClientContext oauth2ClientContext) {
-		super();
+	public ManualOAuthAuthenticationProvider(
+		ResourceServerTokenServices resourceServerTokenServices,
+		OAuth2ClientContext oauth2ClientContext) {
+
+		this.resourceServerTokenServices = resourceServerTokenServices;
 		this.oauth2ClientContext = oauth2ClientContext;
 	}
 
@@ -108,7 +111,7 @@ public class ManualOAuthAuthenticationProvider implements AuthenticationProvider
 		}
 
 		final ManualOAuthAuthenticationDetails details = new ManualOAuthAuthenticationDetails(accessToken);
-		final OAuth2Authentication auth2Authentication = userInfoTokenServices.loadAuthentication(accessToken.getValue());
+		final OAuth2Authentication auth2Authentication = resourceServerTokenServices.loadAuthentication(accessToken.getValue());
 		auth2Authentication.setDetails(details);
 		return auth2Authentication;
 	}

--- a/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/OAuthSecurityConfiguration.java
+++ b/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/OAuthSecurityConfiguration.java
@@ -199,8 +199,6 @@ public class OAuthSecurityConfiguration extends WebSecurityConfigurerAdapter {
 	protected OAuth2RestTemplate oAuth2RestTemplate() {
 		final OAuth2RestTemplate oAuth2RestTemplate = new OAuth2RestTemplate(authorizationCodeResourceDetails,
 				oauth2ClientContext);
-		oAuth2RestTemplate.setAccessTokenProvider(userAccessTokenProvider());
-
 		return oAuth2RestTemplate;
 	}
 
@@ -281,7 +279,6 @@ public class OAuthSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
 		@Override
 		public void configure(ResourceServerSecurityConfigurer resources) throws Exception {
-			// TODO Auto-generated method stub
 			super.configure(resources);
 			resources.tokenServices(resourceServerTokenServices);
 		}

--- a/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/OAuthSecurityConfiguration.java
+++ b/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/OAuthSecurityConfiguration.java
@@ -117,7 +117,6 @@ public class OAuthSecurityConfiguration extends WebSecurityConfigurerAdapter {
 	@Autowired
 	protected AuthorizationProperties authorizationProperties;
 
-
 	@Autowired
 	protected BaseOAuth2ProtectedResourceDetails clientCredentialsResourceDetails;
 
@@ -169,8 +168,11 @@ public class OAuthSecurityConfiguration extends WebSecurityConfigurerAdapter {
 	@Bean
 	protected DataFlowUserInfoTokenServices resourceServerTokenServices() {
 
-		final DataFlowUserInfoTokenServices tokenServices = new DataFlowUserInfoTokenServices(resourceServerProperties.getUserInfoUri(),
-				authorizationCodeResourceDetails.getClientId());
+		final DataFlowUserInfoTokenServices tokenServices = new DataFlowUserInfoTokenServices(
+				resourceServerProperties.getUserInfoUri(),
+				resourceServerProperties.getTokenInfoUri(),
+				authorizationCodeResourceDetails.getClientId(),
+				authorizationCodeResourceDetails.getClientSecret());
 
 		tokenServices.setTokenStore(new InMemoryTokenStore());
 		tokenServices.setSupportRefreshToken(true);

--- a/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/OAuthSecurityConfiguration.java
+++ b/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/OAuthSecurityConfiguration.java
@@ -32,7 +32,7 @@ import org.springframework.boot.autoconfigure.security.SecurityProperties;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.AuthoritiesExtractor;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.PrincipalExtractor;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.ResourceServerProperties;
-import org.springframework.cloud.common.security.support.DataFlowUserInfoTokenServices;
+import org.springframework.cloud.common.security.support.TokenValidatingUserInfoTokenServices;
 import org.springframework.cloud.common.security.support.DataflowPrincipalExtractor;
 import org.springframework.cloud.common.security.support.DefaultAuthoritiesExtractor;
 import org.springframework.cloud.common.security.support.ExternalOauth2ResourceAuthoritiesExtractor;
@@ -166,9 +166,9 @@ public class OAuthSecurityConfiguration extends WebSecurityConfigurerAdapter {
 	}
 
 	@Bean
-	protected DataFlowUserInfoTokenServices resourceServerTokenServices() {
+	protected TokenValidatingUserInfoTokenServices resourceServerTokenServices() {
 
-		final DataFlowUserInfoTokenServices tokenServices = new DataFlowUserInfoTokenServices(
+		final TokenValidatingUserInfoTokenServices tokenServices = new TokenValidatingUserInfoTokenServices(
 				resourceServerProperties.getUserInfoUri(),
 				resourceServerProperties.getTokenInfoUri(),
 				authorizationCodeResourceDetails.getClientId(),

--- a/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/OAuthSecurityConfiguration.java
+++ b/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/OAuthSecurityConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 the original author or authors.
+ * Copyright 2016-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,8 +25,6 @@ import javax.servlet.Filter;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration;
-import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
@@ -34,8 +32,7 @@ import org.springframework.boot.autoconfigure.security.SecurityProperties;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.AuthoritiesExtractor;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.PrincipalExtractor;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.ResourceServerProperties;
-import org.springframework.boot.autoconfigure.security.oauth2.resource.UserInfoTokenServices;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.cloud.common.security.support.DataFlowUserInfoTokenServices;
 import org.springframework.cloud.common.security.support.DataflowPrincipalExtractor;
 import org.springframework.cloud.common.security.support.DefaultAuthoritiesExtractor;
 import org.springframework.cloud.common.security.support.ExternalOauth2ResourceAuthoritiesExtractor;
@@ -60,10 +57,17 @@ import org.springframework.security.oauth2.client.OAuth2ClientContext;
 import org.springframework.security.oauth2.client.OAuth2RestTemplate;
 import org.springframework.security.oauth2.client.filter.OAuth2AuthenticationFailureEvent;
 import org.springframework.security.oauth2.client.filter.OAuth2ClientAuthenticationProcessingFilter;
+import org.springframework.security.oauth2.client.resource.BaseOAuth2ProtectedResourceDetails;
+import org.springframework.security.oauth2.client.token.AccessTokenProvider;
 import org.springframework.security.oauth2.client.token.grant.code.AuthorizationCodeResourceDetails;
+import org.springframework.security.oauth2.client.token.grant.password.ResourceOwnerPasswordAccessTokenProvider;
 import org.springframework.security.oauth2.config.annotation.web.configuration.EnableOAuth2Client;
+import org.springframework.security.oauth2.config.annotation.web.configuration.ResourceServerConfigurerAdapter;
+import org.springframework.security.oauth2.config.annotation.web.configurers.ResourceServerSecurityConfigurer;
 import org.springframework.security.oauth2.provider.authentication.OAuth2AuthenticationManager;
 import org.springframework.security.oauth2.provider.authentication.OAuth2AuthenticationProcessingFilter;
+import org.springframework.security.oauth2.provider.token.ResourceServerTokenServices;
+import org.springframework.security.oauth2.provider.token.store.InMemoryTokenStore;
 import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
 import org.springframework.security.web.authentication.www.BasicAuthenticationEntryPoint;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
@@ -113,6 +117,11 @@ public class OAuthSecurityConfiguration extends WebSecurityConfigurerAdapter {
 	@Autowired
 	protected AuthorizationProperties authorizationProperties;
 
+
+	@Autowired
+	protected BaseOAuth2ProtectedResourceDetails clientCredentialsResourceDetails;
+
+
 	@Autowired(required = false)
 	private PrincipalExtractor principalExtractor;
 
@@ -158,9 +167,14 @@ public class OAuthSecurityConfiguration extends WebSecurityConfigurerAdapter {
 	}
 
 	@Bean
-	protected UserInfoTokenServices tokenServices() {
-		final UserInfoTokenServices tokenServices = new UserInfoTokenServices(resourceServerProperties.getUserInfoUri(),
+	protected DataFlowUserInfoTokenServices resourceServerTokenServices() {
+
+		final DataFlowUserInfoTokenServices tokenServices = new DataFlowUserInfoTokenServices(resourceServerProperties.getUserInfoUri(),
 				authorizationCodeResourceDetails.getClientId());
+
+		tokenServices.setTokenStore(new InMemoryTokenStore());
+		tokenServices.setSupportRefreshToken(true);
+
 		tokenServices.setRestTemplate(oAuth2RestTemplate());
 		final AuthoritiesExtractor authoritiesExtractor;
 		if (StringUtils.isEmpty(authorizationProperties.getExternalAuthoritiesUrl())) {
@@ -185,12 +199,19 @@ public class OAuthSecurityConfiguration extends WebSecurityConfigurerAdapter {
 	protected OAuth2RestTemplate oAuth2RestTemplate() {
 		final OAuth2RestTemplate oAuth2RestTemplate = new OAuth2RestTemplate(authorizationCodeResourceDetails,
 				oauth2ClientContext);
+		oAuth2RestTemplate.setAccessTokenProvider(userAccessTokenProvider());
+
 		return oAuth2RestTemplate;
+	}
+
+	public AccessTokenProvider userAccessTokenProvider() {
+		ResourceOwnerPasswordAccessTokenProvider accessTokenProvider = new ResourceOwnerPasswordAccessTokenProvider();
+		return accessTokenProvider;
 	}
 
 	@Bean
 	protected AuthenticationProvider authenticationProvider() {
-		return new ManualOAuthAuthenticationProvider(oauth2ClientContext);
+		return new ManualOAuthAuthenticationProvider(this.resourceServerTokenServices(), oauth2ClientContext);
 	}
 
 	@Bean
@@ -205,7 +226,7 @@ public class OAuthSecurityConfiguration extends WebSecurityConfigurerAdapter {
 		final OAuth2ClientAuthenticationProcessingFilter oauthFilter = new OAuth2ClientAuthenticationProcessingFilter(
 				"/login");
 		oauthFilter.setRestTemplate(oAuth2RestTemplate());
-		oauthFilter.setTokenServices(tokenServices());
+		oauthFilter.setTokenServices(resourceServerTokenServices());
 		oauthFilter.setApplicationEventPublisher(this.applicationEventPublisher);
 		return oauthFilter;
 	}
@@ -220,7 +241,7 @@ public class OAuthSecurityConfiguration extends WebSecurityConfigurerAdapter {
 	@Bean
 	public AuthenticationManager oauthAuthenticationManager() {
 		final OAuth2AuthenticationManager oauthAuthenticationManager = new OAuth2AuthenticationManager();
-		oauthAuthenticationManager.setTokenServices(tokenServices());
+		oauthAuthenticationManager.setTokenServices(resourceServerTokenServices());
 		return oauthAuthenticationManager;
 	}
 
@@ -251,4 +272,20 @@ public class OAuthSecurityConfiguration extends WebSecurityConfigurerAdapter {
 			return Collections.singletonList(MediaType.APPLICATION_JSON);
 		}
 	}
+
+	@Configuration
+	protected static class ResourceServerConfiguration
+			extends ResourceServerConfigurerAdapter {
+
+		@Autowired ResourceServerTokenServices resourceServerTokenServices;
+
+		@Override
+		public void configure(ResourceServerSecurityConfigurer resources) throws Exception {
+			// TODO Auto-generated method stub
+			super.configure(resources);
+			resources.tokenServices(resourceServerTokenServices);
+		}
+
+	}
+
 }

--- a/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/support/DataFlowUserInfoTokenServices.java
+++ b/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/support/DataFlowUserInfoTokenServices.java
@@ -1,0 +1,362 @@
+package org.springframework.cloud.common.security.support;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.AuthoritiesExtractor;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.FixedAuthoritiesExtractor;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.FixedPrincipalExtractor;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.PrincipalExtractor;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.ResourceServerProperties;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import java.util.Base64;
+import org.springframework.security.oauth2.client.OAuth2RestOperations;
+import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.security.oauth2.common.exceptions.InvalidTokenException;
+import org.springframework.security.oauth2.provider.ClientDetailsService;
+import org.springframework.security.oauth2.provider.ClientRegistrationException;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.security.oauth2.provider.OAuth2Request;
+import org.springframework.security.oauth2.provider.token.AccessTokenConverter;
+import org.springframework.security.oauth2.provider.token.DefaultAccessTokenConverter;
+import org.springframework.security.oauth2.provider.token.DefaultTokenServices;
+import org.springframework.security.oauth2.provider.token.RemoteTokenServices;
+import org.springframework.security.oauth2.provider.token.TokenStore;
+import org.springframework.util.Assert;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.DefaultResponseErrorHandler;
+import org.springframework.web.client.RestOperations;
+import org.springframework.web.client.RestTemplate;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Extension of {@link DefaultTokenServices} that provides the functionality of the {@link RemoteTokenServices}
+ * to validate a passed Access Token from a remote OAuth Server (introspection).
+ *
+ * @author Gunnar Hillert
+ *
+ */
+public class DataFlowUserInfoTokenServices extends DefaultTokenServices {
+
+	protected final Log logger = LogFactory.getLog(getClass());
+
+	@Autowired
+	private ResourceServerProperties resourceServerProperties;
+
+	/**
+	 * Need access to {@link TokenStore}, unfortunately it is private in {@link DefaultTokenServices}.
+	 */
+	private TokenStore tokenStore;
+
+	/**
+	 * Need access to {@link ClientDetailsService}, unfortunately it is private in {@link DefaultTokenServices}.
+	 */
+	private ClientDetailsService clientDetailsService;
+
+	private final String userInfoEndpointUrl;
+
+	private final String clientId;
+
+	private OAuth2RestOperations restTemplate;
+
+	/**
+	 * See also {@link RemoteTokenServices}. Property name to set on a post request to
+	 * introspect an OAuth Token. Defaults to {@code token}.
+	 *
+	 * For UAA see: https://docs.cloudfoundry.org/api/uaa/version/4.26.0/index.html#introspect-token
+	 */
+	private String tokenName = "token";
+
+	private AuthoritiesExtractor authoritiesExtractor = new FixedAuthoritiesExtractor();
+
+	private PrincipalExtractor principalExtractor = new FixedPrincipalExtractor();
+
+	private RestOperations remoteTokenRestTemplate;
+	private AccessTokenConverter tokenConverter = new DefaultAccessTokenConverter();
+
+	public DataFlowUserInfoTokenServices(String userInfoEndpointUrl, String clientId) {
+		this.userInfoEndpointUrl = userInfoEndpointUrl;
+		this.clientId = clientId;
+
+		final ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.configure(DeserializationFeature.USE_LONG_FOR_INTS, true);
+		final RestTemplate localRestTemplate = new RestTemplate();
+
+		final MappingJackson2HttpMessageConverter messageConverter = new MappingJackson2HttpMessageConverter();
+		messageConverter.setPrettyPrint(false);
+
+		messageConverter.setObjectMapper(objectMapper);
+		localRestTemplate.getMessageConverters().removeIf(
+			m -> m.getClass().getName().equals(MappingJackson2HttpMessageConverter.class.getName()));
+		localRestTemplate.getMessageConverters().add(messageConverter);
+
+		localRestTemplate.setErrorHandler(new DefaultResponseErrorHandler() {
+			@Override
+			public void handleError(ClientHttpResponse response) throws IOException {
+				if (response.getRawStatusCode() != 400) {
+					super.handleError(response);
+				}
+			}
+		});
+		this.remoteTokenRestTemplate = localRestTemplate;
+	}
+
+	public void setRestTemplate(OAuth2RestOperations restTemplate) {
+		this.restTemplate = restTemplate;
+	}
+
+	public void setAuthoritiesExtractor(AuthoritiesExtractor authoritiesExtractor) {
+		Assert.notNull(authoritiesExtractor, "AuthoritiesExtractor must not be null");
+		this.authoritiesExtractor = authoritiesExtractor;
+	}
+
+	public void setPrincipalExtractor(PrincipalExtractor principalExtractor) {
+		Assert.notNull(principalExtractor, "PrincipalExtractor must not be null");
+		this.principalExtractor = principalExtractor;
+	}
+
+	@Override
+	public OAuth2Authentication loadAuthentication(String accessTokenValue)
+			throws AuthenticationException, InvalidTokenException {
+
+		boolean needToreload = false;
+
+		final OAuth2AccessToken accessToken = this.tokenStore.readAccessToken(accessTokenValue);
+		if (accessToken == null) {
+			needToreload = true;
+		}
+		else if (accessToken.isExpired()) {
+			tokenStore.removeAccessToken(accessToken);
+			throw new InvalidTokenException("Access token expired: " + accessTokenValue);
+		}
+
+		final OAuth2Authentication authenticationToreturn;
+
+		if (needToreload) {
+			final OAuth2Authentication authentication = retrieveOAuth2AuthenticationFromOAuthServer(accessTokenValue);
+			authenticationToreturn = authentication;
+		}
+		else {
+			final OAuth2Authentication authenticationFromTokenStore = tokenStore.readAuthentication(accessToken);
+			if (authenticationFromTokenStore == null) {
+				// in case of race condition
+				throw new InvalidTokenException("Invalid access token: " + accessTokenValue);
+			}
+			if (clientDetailsService != null) {
+				String clientId = authenticationFromTokenStore.getOAuth2Request().getClientId();
+				try {
+					clientDetailsService.loadClientByClientId(clientId);
+				}
+				catch (ClientRegistrationException e) {
+					throw new InvalidTokenException("Client not valid: " + clientId, e);
+				}
+			}
+			authenticationToreturn = authenticationFromTokenStore;
+		}
+
+		return authenticationToreturn;
+	}
+
+	private OAuth2Authentication retrieveOAuth2AuthenticationFromOAuthServer(String accessTokenValue) {
+
+		// First we need to validate the token
+
+		final OAuth2AccessToken remoteOAuth2AccessToken = retrieveAccessTokenFromOAuthServer(accessTokenValue);
+		this.restTemplate.getOAuth2ClientContext().setAccessToken(remoteOAuth2AccessToken);
+
+		// Now let's update the User Information
+		final Map<String, Object> map = getUserInfoMap(this.userInfoEndpointUrl);
+		if (map.containsKey("error")) {
+			if (this.logger.isDebugEnabled()) {
+				this.logger.debug("userinfo returned error: " + map.get("error"));
+			}
+			throw new InvalidTokenException(accessTokenValue);
+		}
+		final OAuth2Authentication authentication = extractAuthentication(map);
+		this.tokenStore.storeAccessToken(remoteOAuth2AccessToken, authentication);
+		return authentication;
+	}
+
+	private OAuth2Authentication extractAuthentication(Map<String, Object> map) {
+		Object principal = getPrincipal(map);
+		List<GrantedAuthority> authorities = this.authoritiesExtractor
+				.extractAuthorities(map);
+		OAuth2Request request = new OAuth2Request(null, this.clientId, null, true, null,
+				null, null, null, null);
+		UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(
+				principal, "N/A", authorities);
+		token.setDetails(map);
+		return new OAuth2Authentication(request, token);
+	}
+
+	/**
+	 * Return the principal that should be used for the token. The default implementation
+	 * delegates to the {@link PrincipalExtractor}.
+	 * @param map the source map
+	 * @return the principal or {@literal "unknown"}
+	 */
+	protected Object getPrincipal(Map<String, Object> map) {
+		Object principal = this.principalExtractor.extractPrincipal(map);
+		return (principal == null ? "unknown" : principal);
+	}
+
+	@Override
+	public OAuth2AccessToken readAccessToken(String accessToken) {
+		throw new UnsupportedOperationException("Not supported: read access token");
+	}
+
+	@SuppressWarnings({ "unchecked" })
+	private Map<String, Object> getUserInfoMap(String userInfoEndpointUrl) {
+		if (this.logger.isDebugEnabled()) {
+			this.logger.debug("Getting user info from: " + userInfoEndpointUrl);
+		}
+		try {
+			return restTemplate.getForEntity(userInfoEndpointUrl, Map.class).getBody();
+		}
+		catch (Exception ex) {
+			this.logger.warn("Could not fetch user details: " + ex.getClass() + ", "
+					+ ex.getMessage());
+			return Collections.<String, Object>singletonMap("error",
+					"Could not fetch user details");
+		}
+	}
+
+	/**
+	 *
+	 * This method will take a received accessToken and call the introspection endpoint of the
+	 * OAuth provider to validate the token and retrieved the associated scopes associated with the token.
+	 *
+	 * Keep in mind that introspection is not standardized by the specs:
+	 *
+	 * https://stackoverflow.com/questions/12296017/how-to-validate-an-oauth-2-0-access-token-for-a-resource-server
+	 *
+	 * <ul>
+	 * <li>https://tools.ietf.org/html/rfc7662
+	 * <li>https://docs.cloudfoundry.org/api/uaa/version/4.26.0/index.html#introspect-token
+	 * <li>https://github.com/spring-projects/spring-security-oauth/issues/1558
+	 * </ul>
+	 *
+	 * In your OAuth Configuration, please make sure to provide the following properties:
+	 *
+	 * security.oauth2.resource.userInfoUri=http://localhost:8080/uaa/userinfo
+     * security.oauth2.resource.tokenInfoUri: http://localhost:8080/uaa/check_token
+     *
+     * see also ResourceServerTokenServicesConfiguration
+     *
+	 * @param accessToken
+	 * @return
+	 */
+	protected OAuth2AccessToken retrieveAccessTokenFromOAuthServer(String accessToken) {
+		Assert.hasText(accessToken, "accessToken must not be null or empty.");
+		MultiValueMap<String, String> formData = new LinkedMultiValueMap<String, String>();
+		formData.add(tokenName, accessToken);
+		HttpHeaders headers = new HttpHeaders();
+		headers.set("Authorization", getAuthorizationHeader(clientId, resourceServerProperties.getClientSecret()));
+
+		Map<String, Object> map = postForMap(resourceServerProperties.getTokenInfoUri(), formData, headers);
+
+		if (map.containsKey("error")) {
+			if (this.logger.isDebugEnabled()) {
+				this.logger.debug("userinfo returned error: " + map.get("error"));
+			}
+			throw new InvalidTokenException(accessToken);
+		}
+
+		return this.tokenConverter.extractAccessToken(accessToken, map);
+	}
+
+	/**
+	 *
+	 * Copied from {@link RemoteTokenServices}.
+	 *
+	 * @param clientId
+	 * @param clientSecret
+	 * @return
+	 *
+	 */
+	protected String getAuthorizationHeader(String clientId, String clientSecret) {
+
+		if(clientId == null || clientSecret == null) {
+			logger.warn("Null Client ID or Client Secret detected. Endpoint that requires authentication will reject request with 401 error.");
+		}
+
+		String creds = String.format("%s:%s", clientId, clientSecret);
+		try {
+			return "Basic " + new String(Base64.getEncoder().encode(creds.getBytes("UTF-8")));
+		}
+		catch (UnsupportedEncodingException e) {
+			throw new IllegalStateException("Could not convert String");
+		}
+	}
+
+	/**
+	 *
+	 * Copied from {@link RemoteTokenServices}.
+	 *
+	 * @param path
+	 * @param formData
+	 * @param headers
+	 *
+	 */
+	protected Map<String, Object> postForMap(String path, MultiValueMap<String, String> formData, HttpHeaders headers) {
+		if (headers.getContentType() == null) {
+			headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+		}
+		@SuppressWarnings("unchecked")
+		Map<String, Object> result = this.remoteTokenRestTemplate.exchange(path, HttpMethod.POST,
+				new HttpEntity<MultiValueMap<String, String>>(formData, headers), Map.class).getBody();
+		return result;
+	}
+
+	/**
+	 * The persistence strategy for token storage.
+	 *
+	 * @param tokenStore the store for access and refresh tokens.
+	 */
+	public void setTokenStore(TokenStore tokenStore) {
+		Assert.notNull(tokenStore, "tokenStore cannot be null.");
+		super.setTokenStore(tokenStore);
+		this.tokenStore = tokenStore;
+	}
+
+	/**
+	 * The client details service to use for looking up clients (if necessary). Optional if the access token expiration is
+	 * set globally via {@link #setAccessTokenValiditySeconds(int)}.
+	 *
+	 * @param clientDetailsService the client details service
+	 */
+	public void setClientDetailsService(ClientDetailsService clientDetailsService) {
+		Assert.notNull(clientDetailsService, "clientDetailsService cannot be null.");
+		super.setClientDetailsService(clientDetailsService);
+		this.clientDetailsService = clientDetailsService;
+	}
+
+	/**
+	 * See also {@link RemoteTokenServices}. Property name to set on a post request to
+	 * introspect an OAuth Token. Defaults to {@code token}.
+	 *
+	 * For UAA see: https://docs.cloudfoundry.org/api/uaa/version/4.26.0/index.html#introspect-token
+	 */
+	public void setTokenName(String tokenName) {
+		Assert.hasText(tokenName, "tokenName cannot be null nor empty.");
+		this.tokenName = tokenName;
+	}
+
+}

--- a/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/support/TokenValidatingUserInfoTokenServices.java
+++ b/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/support/TokenValidatingUserInfoTokenServices.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.cloud.common.security.support;
 
 import java.io.IOException;
@@ -51,7 +66,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * @author Gunnar Hillert
  *
  */
-public class DataFlowUserInfoTokenServices extends DefaultTokenServices {
+public class TokenValidatingUserInfoTokenServices extends DefaultTokenServices {
 
 	protected final Log logger = LogFactory.getLog(getClass());
 
@@ -96,7 +111,7 @@ public class DataFlowUserInfoTokenServices extends DefaultTokenServices {
 	 * @param clientId Must not be empty
 	 * @param clientSecret Must not be empty
 	 */
-	public DataFlowUserInfoTokenServices(
+	public TokenValidatingUserInfoTokenServices(
 			String userInfoEndpointUrl, String tokenInfoUri,
 			String clientId, String clientSecret) {
 


### PR DESCRIPTION
* Add class ` DataFlowUserInfoTokenServices` which is an extension of `DefaultTokenServices` that provides the functionality of the `RemoteTokenServices`
* Add Tests

~requires https://github.com/spring-cloud/spring-cloud-common-security-config/pull/32~
resolves #33
depended on by https://github.com/spring-cloud/spring-cloud-dataflow/pull/2790