### PR TITLE
URL Cleanup

### DIFF
--- a/spring-cloud-common-security-config-web/src/test/java/org/springframework/cloud/common/security/support/ExternalOauth2ResourceAuthoritiesExtractorTests.java
+++ b/spring-cloud-common-security-config-web/src/test/java/org/springframework/cloud/common/security/support/ExternalOauth2ResourceAuthoritiesExtractorTests.java
@@ -48,9 +48,9 @@ public class ExternalOauth2ResourceAuthoritiesExtractorTests {
 	@Test
 	public void testExtractAuthorities() {
 		assertAuthorities(URI.create("http://test/authorities"), "VIEW");
-		assertAuthorities(URI.create("http://the.authorities.server/authorities"), "VIEW", "CREATE", "MANAGE");
-		assertAuthorities(URI.create("http://server/"), "MANAGE");
-		assertAuthorities(URI.create("http://scdf2/"), "DEPLOY", "DESTROY", "MODIFY", "SCHEDULE");
+		assertAuthorities(URI.create("https://the.authorities.server/authorities"), "VIEW", "CREATE", "MANAGE");
+		assertAuthorities(URI.create("https://server/"), "MANAGE");
+		assertAuthorities(URI.create("https://scdf2/"), "DEPLOY", "DESTROY", "MODIFY", "SCHEDULE");
 	}
 
 	private void assertAuthorities(URI uri, String... roles) {


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://scdf2/ (UnknownHostException) with 1 occurrences migrated to:  
  https://scdf2/ ([https](https://scdf2/) result UnknownHostException).
* [ ] http://server/ (UnknownHostException) with 1 occurrences migrated to:  
  https://server/ ([https](https://server/) result UnknownHostException).
* [ ] http://the.authorities.server/authorities (UnknownHostException) with 1 occurrences migrated to:  
  https://the.authorities.server/authorities ([https](https://the.authorities.server/authorities) result UnknownHostException).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8080/uaa/check_token with 1 occurrences
* http://localhost:8080/uaa/userinfo with 1 occurrences
* http://test/authorities with 1 occurrences