### PR TITLE
Add jwt token support

### DIFF
--- a/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/support/DefaultOAuth2TokenUtilsService.java
+++ b/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/support/DefaultOAuth2TokenUtilsService.java
@@ -21,7 +21,9 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.AbstractOAuth2Token;
 import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthentication;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -63,8 +65,12 @@ public class DefaultOAuth2TokenUtilsService implements OAuth2TokenUtilsService {
 			final OAuth2AuthorizedClient oauth2AuthorizedClient = this.getAuthorizedClient(oauth2AuthenticationToken);
 			accessTokenOfAuthenticatedUser = oauth2AuthorizedClient.getAccessToken().getTokenValue();
 		}
+		else if (authentication instanceof JwtAuthenticationToken) {
+			AbstractOAuth2Token token = (AbstractOAuth2Token) authentication.getCredentials();
+			accessTokenOfAuthenticatedUser = token.getTokenValue();
+		}
 		else {
-			throw new IllegalStateException("Authentication object is not of type OAuth2AuthenticationToken.");
+			throw new IllegalStateException("Unsupported authentication object type " + authentication);
 		}
 
 		return accessTokenOfAuthenticatedUser;

--- a/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/support/MappingJwtGrantedAuthoritiesConverter.java
+++ b/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/support/MappingJwtGrantedAuthoritiesConverter.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.common.security.support;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * Extracts the {@link GrantedAuthority}s from scope attributes typically found in a
+ * {@link Jwt}.
+ */
+public final class MappingJwtGrantedAuthoritiesConverter implements Converter<Jwt, Collection<GrantedAuthority>> {
+	private static final String DEFAULT_AUTHORITY_PREFIX = "SCOPE_";
+
+	private static final Collection<String> WELL_KNOWN_AUTHORITIES_CLAIM_NAMES =
+			Arrays.asList("scope", "scp");
+
+	private String authorityPrefix = DEFAULT_AUTHORITY_PREFIX;
+
+	private String authoritiesClaimName;
+
+	private Map<String, String> authoritiesMapping = new HashMap<>();
+
+	/**
+	 * Extract {@link GrantedAuthority}s from the given {@link Jwt}.
+	 *
+	 * @param jwt The {@link Jwt} token
+	 * @return The {@link GrantedAuthority authorities} read from the token scopes
+	 */
+	@Override
+	public Collection<GrantedAuthority> convert(Jwt jwt) {
+		return getAuthorities(jwt).stream()
+			.flatMap(authority -> {
+				if (authoritiesMapping.isEmpty()) {
+					return Stream.of(authority);
+				}
+				return authoritiesMapping.entrySet().stream()
+					.filter(entry -> entry.getValue().equals(authority))
+					.map(entry -> entry.getKey()).distinct();
+			})
+			.distinct()
+			.map(authority -> new SimpleGrantedAuthority(this.authorityPrefix + authority))
+			.collect(Collectors.toSet());
+	}
+
+	/**
+	 * Sets the prefix to use for {@link GrantedAuthority authorities} mapped by this converter.
+	 * Defaults to {@link JwtGrantedAuthoritiesConverter#DEFAULT_AUTHORITY_PREFIX}.
+	 *
+	 * @param authorityPrefix The authority prefix
+	 */
+	public void setAuthorityPrefix(String authorityPrefix) {
+		Assert.notNull(authorityPrefix, "authorityPrefix cannot be null");
+		this.authorityPrefix = authorityPrefix;
+	}
+
+	/**
+	 * Sets the name of token claim to use for mapping {@link GrantedAuthority authorities} by this converter.
+	 * Defaults to {@link JwtGrantedAuthoritiesConverter#WELL_KNOWN_AUTHORITIES_CLAIM_NAMES}.
+	 *
+	 * @param authoritiesClaimName The token claim name to map authorities
+	 */
+	public void setAuthoritiesClaimName(String authoritiesClaimName) {
+		Assert.hasText(authoritiesClaimName, "authoritiesClaimName cannot be empty");
+		this.authoritiesClaimName = authoritiesClaimName;
+	}
+
+	/**
+	 * Set the mapping from resolved authorities from jwt into granted authorities.
+	 *
+	 * @param authoritiesMapping the authoritiesMapping to set
+	 */
+	public void setAuthoritiesMapping(Map<String, String> authoritiesMapping) {
+		Assert.notNull(authoritiesMapping, "authoritiesMapping cannot be null");
+		this.authoritiesMapping = authoritiesMapping;
+	}
+
+	private String getAuthoritiesClaimName(Jwt jwt) {
+
+		if (this.authoritiesClaimName != null) {
+			return this.authoritiesClaimName;
+		}
+
+		for (String claimName : WELL_KNOWN_AUTHORITIES_CLAIM_NAMES) {
+			if (jwt.containsClaim(claimName)) {
+				return claimName;
+			}
+		}
+		return null;
+	}
+
+	private Collection<String> getAuthorities(Jwt jwt) {
+		String claimName = getAuthoritiesClaimName(jwt);
+
+		if (claimName == null) {
+			return Collections.emptyList();
+		}
+
+		Object authorities = jwt.getClaim(claimName);
+		if (authorities instanceof String) {
+			if (StringUtils.hasText((String) authorities)) {
+				return Arrays.asList(((String) authorities).split(" "));
+			} else {
+				return Collections.emptyList();
+			}
+		} else if (authorities instanceof Collection) {
+			return (Collection<String>) authorities;
+		}
+
+		return Collections.emptyList();
+	}
+}

--- a/spring-cloud-common-security-config-web/src/test/java/org/springframework/cloud/common/security/support/MappingJwtGrantedAuthoritiesConverterTests.java
+++ b/spring-cloud-common-security-config-web/src/test/java/org/springframework/cloud/common/security/support/MappingJwtGrantedAuthoritiesConverterTests.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.common.security.support;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link MappingJwtGrantedAuthoritiesConverter}
+ *
+ */
+public class MappingJwtGrantedAuthoritiesConverterTests {
+
+	public static Jwt.Builder jwt() {
+		return Jwt.withTokenValue("token")
+				.header("alg", "none")
+				.audience(Arrays.asList("https://audience.example.org"))
+				.expiresAt(Instant.MAX)
+				.issuedAt(Instant.MIN)
+				.issuer("https://issuer.example.org")
+				.jti("jti")
+				.notBefore(Instant.MIN)
+				.subject("mock-test-subject");
+	}
+
+	public static Jwt user() {
+		return jwt()
+				.claim("sub", "mock-test-subject")
+				.build();
+	}
+
+	@Test
+	public void convertWhenTokenHasScopeAttributeThenTranslatedToAuthorities() {
+		Jwt jwt = jwt().claim("scope", "message:read message:write").build();
+
+		MappingJwtGrantedAuthoritiesConverter jwtGrantedAuthoritiesConverter = new MappingJwtGrantedAuthoritiesConverter();
+		Collection<GrantedAuthority> authorities = jwtGrantedAuthoritiesConverter.convert(jwt);
+
+		assertThat(authorities).containsExactlyInAnyOrder(
+				new SimpleGrantedAuthority("SCOPE_message:read"),
+				new SimpleGrantedAuthority("SCOPE_message:write"));
+	}
+
+	@Test
+	public void convertWithCustomAuthorityPrefixWhenTokenHasScopeAttributeThenTranslatedToAuthoritiesViaMapping() {
+		Jwt jwt = jwt().claim("scope", "message:read message:write").build();
+
+		MappingJwtGrantedAuthoritiesConverter jwtGrantedAuthoritiesConverter = new MappingJwtGrantedAuthoritiesConverter();
+		jwtGrantedAuthoritiesConverter.setAuthorityPrefix("ROLE_");
+		Map<String, String> authoritiesMapping = new HashMap<>();
+		authoritiesMapping.put("READ", "message:read");
+		authoritiesMapping.put("WRITE", "message:write");
+		jwtGrantedAuthoritiesConverter.setAuthoritiesMapping(authoritiesMapping);
+		Collection<GrantedAuthority> authorities = jwtGrantedAuthoritiesConverter.convert(jwt);
+
+		assertThat(authorities).containsExactly(
+				new SimpleGrantedAuthority("ROLE_READ"),
+				new SimpleGrantedAuthority("ROLE_WRITE"));
+	}
+
+	@Test
+	public void convertWithCustomAuthorityWhenTokenHasScopeAttributeThenTranslatedToAuthoritiesViaMapping() {
+		Jwt jwt = jwt().claim("scope", "message:read message:write").build();
+
+		MappingJwtGrantedAuthoritiesConverter jwtGrantedAuthoritiesConverter = new MappingJwtGrantedAuthoritiesConverter();
+		jwtGrantedAuthoritiesConverter.setAuthorityPrefix("");
+		Map<String, String> authoritiesMapping = new HashMap<>();
+		authoritiesMapping.put("ROLE_READ", "message:read");
+		authoritiesMapping.put("ROLE_WRITE", "message:write");
+		jwtGrantedAuthoritiesConverter.setAuthoritiesMapping(authoritiesMapping);
+		Collection<GrantedAuthority> authorities = jwtGrantedAuthoritiesConverter.convert(jwt);
+
+		assertThat(authorities).containsExactly(
+				new SimpleGrantedAuthority("ROLE_READ"),
+				new SimpleGrantedAuthority("ROLE_WRITE"));
+	}
+
+	@Test
+	public void convertWithCustomAuthorityPrefixWhenTokenHasScopeAttributeThenTranslatedToAuthorities() {
+		Jwt jwt = jwt().claim("scope", "message:read message:write").build();
+
+		MappingJwtGrantedAuthoritiesConverter jwtGrantedAuthoritiesConverter = new MappingJwtGrantedAuthoritiesConverter();
+		jwtGrantedAuthoritiesConverter.setAuthorityPrefix("ROLE_");
+		Collection<GrantedAuthority> authorities = jwtGrantedAuthoritiesConverter.convert(jwt);
+
+		assertThat(authorities).containsExactlyInAnyOrder(
+				new SimpleGrantedAuthority("ROLE_message:read"),
+				new SimpleGrantedAuthority("ROLE_message:write"));
+	}
+
+	@Test
+	public void convertWhenTokenHasEmptyScopeAttributeThenTranslatedToNoAuthorities() {
+		Jwt jwt = jwt().claim("scope", "").build();
+
+		MappingJwtGrantedAuthoritiesConverter jwtGrantedAuthoritiesConverter = new MappingJwtGrantedAuthoritiesConverter();
+		Collection<GrantedAuthority> authorities = jwtGrantedAuthoritiesConverter.convert(jwt);
+
+		assertThat(authorities).isEmpty();
+	}
+
+	@Test
+	public void convertWhenTokenHasScpAttributeThenTranslatedToAuthorities() {
+		Jwt jwt = jwt().claim("scp", Arrays.asList("message:read", "message:write")).build();
+
+		MappingJwtGrantedAuthoritiesConverter jwtGrantedAuthoritiesConverter = new MappingJwtGrantedAuthoritiesConverter();
+		Collection<GrantedAuthority> authorities = jwtGrantedAuthoritiesConverter.convert(jwt);
+
+		assertThat(authorities).containsExactlyInAnyOrder(
+				new SimpleGrantedAuthority("SCOPE_message:read"),
+				new SimpleGrantedAuthority("SCOPE_message:write"));
+	}
+
+	@Test
+	public void convertWithCustomAuthorityPrefixWhenTokenHasScpAttributeThenTranslatedToAuthorities() {
+		Jwt jwt = jwt().claim("scp", Arrays.asList("message:read", "message:write")).build();
+
+		MappingJwtGrantedAuthoritiesConverter jwtGrantedAuthoritiesConverter = new MappingJwtGrantedAuthoritiesConverter();
+		jwtGrantedAuthoritiesConverter.setAuthorityPrefix("ROLE_");
+		Collection<GrantedAuthority> authorities = jwtGrantedAuthoritiesConverter.convert(jwt);
+
+		assertThat(authorities).containsExactlyInAnyOrder(
+				new SimpleGrantedAuthority("ROLE_message:read"),
+				new SimpleGrantedAuthority("ROLE_message:write"));
+	}
+
+	@Test
+	public void convertWhenTokenHasEmptyScpAttributeThenTranslatedToNoAuthorities() {
+		Jwt jwt = jwt().claim("scp", Collections.emptyList()).build();
+
+		MappingJwtGrantedAuthoritiesConverter jwtGrantedAuthoritiesConverter = new MappingJwtGrantedAuthoritiesConverter();
+		Collection<GrantedAuthority> authorities = jwtGrantedAuthoritiesConverter.convert(jwt);
+
+		assertThat(authorities).isEmpty();
+	}
+
+	@Test
+	public void convertWhenTokenHasBothScopeAndScpThenScopeAttributeIsTranslatedToAuthorities() {
+		Jwt jwt = jwt()
+			.claim("scp", Arrays.asList("message:read", "message:write"))
+			.claim("scope", "missive:read missive:write")
+			.build();
+
+		MappingJwtGrantedAuthoritiesConverter jwtGrantedAuthoritiesConverter = new MappingJwtGrantedAuthoritiesConverter();
+		Collection<GrantedAuthority> authorities = jwtGrantedAuthoritiesConverter.convert(jwt);
+
+		assertThat(authorities).containsExactly(
+				new SimpleGrantedAuthority("SCOPE_missive:read"),
+				new SimpleGrantedAuthority("SCOPE_missive:write"));
+	}
+
+	@Test
+	public void convertWhenTokenHasEmptyScopeAndNonEmptyScpThenScopeAttributeIsTranslatedToNoAuthorities() {
+		Jwt jwt = jwt()
+			.claim("scp", Arrays.asList("message:read", "message:write"))
+			.claim("scope", "")
+			.build();
+
+		MappingJwtGrantedAuthoritiesConverter jwtGrantedAuthoritiesConverter = new MappingJwtGrantedAuthoritiesConverter();
+		Collection<GrantedAuthority> authorities = jwtGrantedAuthoritiesConverter.convert(jwt);
+
+		assertThat(authorities).isEmpty();
+	}
+
+	@Test
+	public void convertWhenTokenHasEmptyScopeAndEmptyScpAttributeThenTranslatesToNoAuthorities() {
+		Jwt jwt = jwt()
+			.claim("scp", Collections.emptyList())
+			.claim("scope", Collections.emptyList())
+			.build();
+
+		MappingJwtGrantedAuthoritiesConverter jwtGrantedAuthoritiesConverter = new MappingJwtGrantedAuthoritiesConverter();
+		Collection<GrantedAuthority> authorities = jwtGrantedAuthoritiesConverter.convert(jwt);
+
+		assertThat(authorities).isEmpty();
+	}
+
+	@Test
+	public void convertWhenTokenHasNoScopeAndNoScpAttributeThenTranslatesToNoAuthorities() {
+		Jwt jwt = jwt().claim("roles", Arrays.asList("message:read", "message:write")).build();
+
+		MappingJwtGrantedAuthoritiesConverter jwtGrantedAuthoritiesConverter = new MappingJwtGrantedAuthoritiesConverter();
+		Collection<GrantedAuthority> authorities = jwtGrantedAuthoritiesConverter.convert(jwt);
+
+		assertThat(authorities).isEmpty();
+	}
+
+	@Test
+	public void convertWhenTokenHasUnsupportedTypeForScopeThenTranslatesToNoAuthorities() {
+		Jwt jwt = jwt().claim("scope", new String[] {"message:read", "message:write"}).build();
+
+		MappingJwtGrantedAuthoritiesConverter jwtGrantedAuthoritiesConverter = new MappingJwtGrantedAuthoritiesConverter();
+		Collection<GrantedAuthority> authorities = jwtGrantedAuthoritiesConverter.convert(jwt);
+
+		assertThat(authorities).isEmpty();
+	}
+
+	@Test
+	public void convertWhenTokenHasCustomClaimNameThenCustomClaimNameAttributeIsTranslatedToAuthorities() {
+		Jwt jwt = jwt()
+				.claim("roles", Arrays.asList("message:read", "message:write"))
+				.claim("scope", "missive:read missive:write")
+				.build();
+
+		MappingJwtGrantedAuthoritiesConverter jwtGrantedAuthoritiesConverter = new MappingJwtGrantedAuthoritiesConverter();
+		jwtGrantedAuthoritiesConverter.setAuthoritiesClaimName("roles");
+		Collection<GrantedAuthority> authorities = jwtGrantedAuthoritiesConverter.convert(jwt);
+
+		assertThat(authorities).containsExactlyInAnyOrder(
+				new SimpleGrantedAuthority("SCOPE_message:read"),
+				new SimpleGrantedAuthority("SCOPE_message:write"));
+	}
+
+	@Test
+	public void convertWhenTokenHasEmptyCustomClaimNameThenCustomClaimNameAttributeIsTranslatedToNoAuthorities() {
+		Jwt jwt = jwt()
+				.claim("roles", Collections.emptyList())
+				.claim("scope", "missive:read missive:write")
+				.build();
+
+		MappingJwtGrantedAuthoritiesConverter jwtGrantedAuthoritiesConverter = new MappingJwtGrantedAuthoritiesConverter();
+		jwtGrantedAuthoritiesConverter.setAuthoritiesClaimName("roles");
+		Collection<GrantedAuthority> authorities = jwtGrantedAuthoritiesConverter.convert(jwt);
+
+		assertThat(authorities).isEmpty();
+	}
+
+	@Test
+	public void convertWhenTokenHasNoCustomClaimNameThenCustomClaimNameAttributeIsTranslatedToNoAuthorities() {
+		Jwt jwt = jwt().claim("scope", "missive:read missive:write").build();
+
+		MappingJwtGrantedAuthoritiesConverter jwtGrantedAuthoritiesConverter = new MappingJwtGrantedAuthoritiesConverter();
+		jwtGrantedAuthoritiesConverter.setAuthoritiesClaimName("roles");
+		Collection<GrantedAuthority> authorities = jwtGrantedAuthoritiesConverter.convert(jwt);
+
+		assertThat(authorities).isEmpty();
+	}
+}

--- a/spring-cloud-common-security-config-web/src/test/java/org/springframework/cloud/common/security/support/OAuth2TokenUtilsServiceTests.java
+++ b/spring-cloud-common-security-config-web/src/test/java/org/springframework/cloud/common/security/support/OAuth2TokenUtilsServiceTests.java
@@ -32,6 +32,7 @@ import org.springframework.security.oauth2.core.OAuth2AccessToken.TokenType;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -73,9 +74,7 @@ public class OAuth2TokenUtilsServiceTests {
 			oAuth2TokenUtilsService.getAccessTokenOfAuthenticatedUser();
 		}
 		catch (IllegalStateException e) {
-			assertEquals(
-				"Authentication object is not of type OAuth2AuthenticationToken.",
-				e.getMessage());
+			assertTrue(e.getMessage().startsWith("Unsupported authentication object type"));
 			SecurityContextHolder.getContext().setAuthentication(null);
 			return;
 		}


### PR DESCRIPTION
- Now conditionally using jwt support for resource server which
  allows to work with azure AD without requiring opaque token.
- MappingJwtGrantedAuthoritiesConverter is mapping scopes from a token
  back to spring-security authorities.
- Relates #73
- Relates #74