### PR TITLE
Basic support for mapping group claims

### DIFF
--- a/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/OAuthSecurityConfiguration.java
+++ b/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/OAuthSecurityConfiguration.java
@@ -216,6 +216,7 @@ public class OAuthSecurityConfiguration extends WebSecurityConfigurerAdapter {
 		jwtAuthenticationConverter.setJwtGrantedAuthoritiesConverter(converter);
 		if (providerRoleMapping != null) {
 			converter.setAuthoritiesMapping(providerRoleMapping.getRoleMappings());
+			converter.setGroupAuthoritiesMapping(providerRoleMapping.getGroupMappings());
 		}
 		return jwtAuthenticationConverter;
 	}

--- a/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/support/AuthoritiesMapper.java
+++ b/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/support/AuthoritiesMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,28 +15,38 @@
  */
 package org.springframework.cloud.common.security.support;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 import org.springframework.security.core.GrantedAuthority;
 
 /**
+ * Maps scopes and claims into authorities.
  *
  * @author Gunnar Hillert
- *
- * @since 1.3.0
- *
+ * @author Janne Valkealahti
  */
 public interface AuthoritiesMapper {
 
 	/**
-	 * Map the provided Scopes to authorities.
+	 * Map the provided scopes to authorities.
 	 *
 	 * @param providerId If null, then the default providerId is used
 	 * @param scopes the scopes to map
 	 * @param token some implementation may need to make additional requests
-	 *
 	 * @return the mapped authorities
 	 */
 	Set<GrantedAuthority> mapScopesToAuthorities(String providerId, Set<String> scopes, String token);
 
+	/**
+	 * Map the provided claims to authorities.
+	 *
+	 * @param providerId If null, then the default providerId is used
+	 * @param claims the claims to map
+	 * @return the mapped authorities
+	 */
+	default Set<GrantedAuthority> mapClaimsToAuthorities(String providerId, List<String> claims) {
+		return Collections.emptySet();
+	}
 }

--- a/spring-cloud-common-security-config-web/src/test/java/org/springframework/cloud/common/security/support/DefaultAuthoritiesMapperTests.java
+++ b/spring-cloud-common-security-config-web/src/test/java/org/springframework/cloud/common/security/support/DefaultAuthoritiesMapperTests.java
@@ -45,28 +45,22 @@ public class DefaultAuthoritiesMapperTests {
 
 	@Test
 	public void testMapScopesToAuthoritiesWithNullParameters() throws Exception {
-		final DefaultAuthoritiesMapper authoritiesMapper = new DefaultAuthoritiesMapper(Collections.emptyMap(), "");
+		DefaultAuthoritiesMapper authoritiesMapper = new DefaultAuthoritiesMapper(Collections.emptyMap(), "");
+
 		assertThatThrownBy(() -> {
 			authoritiesMapper.mapScopesToAuthorities(null, null, null);
 		}).isInstanceOf(IllegalArgumentException.class).hasMessageContaining("The scopes argument must not be null.");
-	}
-
-	@Test
-	public void testMapScopesToAuthoritiesWithNullParameters2() throws Exception {
-		final DefaultAuthoritiesMapper authoritiesMapper = new DefaultAuthoritiesMapper(Collections.emptyMap(), "");
 		assertThatThrownBy(() -> {
 			authoritiesMapper.mapScopesToAuthorities("myClientId", null, null);
 		}).isInstanceOf(IllegalArgumentException.class).hasMessageContaining("The scopes argument must not be null.");
 	}
 
-
 	@Test
 	public void testThat7AuthoritiesAreReturned() throws Exception {
-		final DefaultAuthoritiesMapper authoritiesMapper = new DefaultAuthoritiesMapper("uaa", false);
+		DefaultAuthoritiesMapper authoritiesMapper = new DefaultAuthoritiesMapper("uaa", false);
+		Set<GrantedAuthority> authorities = authoritiesMapper.mapScopesToAuthorities("uaa", Collections.emptySet(), null);
 
-		final Set<GrantedAuthority> authorities = authoritiesMapper.mapScopesToAuthorities("uaa", Collections.emptySet(), null);
 		assertThat(authorities).hasSize(7);
-
 		assertThat(authorities.stream().map(authority -> authority.getAuthority()).collect(Collectors.toList()))
 				.containsExactlyInAnyOrder("ROLE_MANAGE", "ROLE_CREATE", "ROLE_VIEW", "ROLE_DEPLOY", "ROLE_MODIFY",
 						"ROLE_SCHEDULE", "ROLE_DESTROY");
@@ -74,26 +68,24 @@ public class DefaultAuthoritiesMapperTests {
 
 	@Test
 	public void testEmptyMapConstructor() throws Exception {
-		final Set<String> scopes = new HashSet<>();
+		Set<String> scopes = new HashSet<>();
 		scopes.add("dataflow.manage");
 		scopes.add("dataflow.view");
 		scopes.add("dataflow.create");
 
-		final DefaultAuthoritiesMapper authoritiesMapper = new DefaultAuthoritiesMapper("uaa", true);
+		DefaultAuthoritiesMapper authoritiesMapper = new DefaultAuthoritiesMapper("uaa", true);
+		Collection<? extends GrantedAuthority> authorities = authoritiesMapper.mapScopesToAuthorities("uaa", scopes, null);
 
-		final Collection<? extends GrantedAuthority> authorities = authoritiesMapper.mapScopesToAuthorities("uaa", scopes, null);
 		assertThat(authorities).hasSize(3);
-
 		assertThat(authorities.stream().map(authority -> authority.getAuthority()).collect(Collectors.toList()))
 				.containsExactlyInAnyOrder("ROLE_MANAGE", "ROLE_CREATE", "ROLE_VIEW");
 	}
 
 	@Test
 	public void testMapConstructorWithIncompleteRoleMappings() throws Exception {
-		final ProviderRoleMapping roleMapping = new ProviderRoleMapping();
+		ProviderRoleMapping roleMapping = new ProviderRoleMapping();
 		roleMapping.setMapOauthScopes(true);
 		roleMapping.addRoleMapping("ROLE_MANAGE", "foo-scope-in-oauth");
-
 		assertThatThrownBy(() -> {
 			new DefaultAuthoritiesMapper("uaa", roleMapping);
 		}).isInstanceOf(IllegalArgumentException.class).hasMessageContaining(
@@ -102,23 +94,20 @@ public class DefaultAuthoritiesMapperTests {
 
 	@Test
 	public void testThat7MappedAuthoritiesAreReturned() throws Exception {
-
-		final Map<String, String> roleMappings = new HashMap<>();
-
+		Map<String, String> roleMappings = new HashMap<>();
 		roleMappings.put("ROLE_MANAGE", "foo-manage");
 		roleMappings.put("ROLE_VIEW", "bar-view");
 		roleMappings.put("ROLE_CREATE", "blubba-create");
-
 		roleMappings.put("ROLE_MODIFY", "foo-modify");
 		roleMappings.put("ROLE_DEPLOY", "foo-deploy");
 		roleMappings.put("ROLE_DESTROY", "foo-destroy");
 		roleMappings.put("ROLE_SCHEDULE", "foo-schedule");
 
-		final ProviderRoleMapping providerRoleMapping = new ProviderRoleMapping();
+		ProviderRoleMapping providerRoleMapping = new ProviderRoleMapping();
 		providerRoleMapping.setMapOauthScopes(true);
 		providerRoleMapping.getRoleMappings().putAll(roleMappings);
 
-		final Set<String> scopes = new HashSet<>();
+		Set<String> scopes = new HashSet<>();
 		scopes.add("foo-manage");
 		scopes.add("bar-view");
 		scopes.add("blubba-create");
@@ -127,12 +116,11 @@ public class DefaultAuthoritiesMapperTests {
 		scopes.add("foo-destroy");
 		scopes.add("foo-schedule");
 
-		final DefaultAuthoritiesMapper defaultAuthoritiesMapper = new DefaultAuthoritiesMapper("uaa", providerRoleMapping);
-
-		final Collection<? extends GrantedAuthority> authorities = defaultAuthoritiesMapper.mapScopesToAuthorities("uaa", scopes, null);
+		DefaultAuthoritiesMapper defaultAuthoritiesMapper = new DefaultAuthoritiesMapper("uaa", providerRoleMapping);
+		Collection<? extends GrantedAuthority> authorities = defaultAuthoritiesMapper.mapScopesToAuthorities("uaa",
+				scopes, null);
 
 		assertThat(authorities).hasSize(7);
-
 		assertThat(authorities.stream().map(authority -> authority.getAuthority()).collect(Collectors.toList()))
 				.containsExactlyInAnyOrder("ROLE_CREATE", "ROLE_DEPLOY", "ROLE_DESTROY", "ROLE_MANAGE", "ROLE_MODIFY",
 						"ROLE_SCHEDULE", "ROLE_VIEW");
@@ -140,42 +128,38 @@ public class DefaultAuthoritiesMapperTests {
 
 	@Test
 	public void testThat3MappedAuthoritiesAreReturnedForDefaultMapping() throws Exception {
-
-		final ProviderRoleMapping providerRoleMapping = new ProviderRoleMapping();
+		ProviderRoleMapping providerRoleMapping = new ProviderRoleMapping();
 		providerRoleMapping.setMapOauthScopes(true);
 
-		final Set<String> scopes = new HashSet<>();
+		Set<String> scopes = new HashSet<>();
 		scopes.add("dataflow.manage");
 		scopes.add("dataflow.view");
 		scopes.add("dataflow.create");
 
-		final DefaultAuthoritiesMapper defaultAuthoritiesExtractor = new DefaultAuthoritiesMapper("uaa", providerRoleMapping);
-
-		final Collection<? extends GrantedAuthority> authorities = defaultAuthoritiesExtractor.mapScopesToAuthorities("uaa", scopes, null);
+		DefaultAuthoritiesMapper defaultAuthoritiesExtractor = new DefaultAuthoritiesMapper("uaa", providerRoleMapping);
+		Collection<? extends GrantedAuthority> authorities = defaultAuthoritiesExtractor.mapScopesToAuthorities("uaa",
+				scopes, null);
 
 		assertThat(authorities).hasSize(3);
-
 		assertThat(authorities.stream().map(authority -> authority.getAuthority()).collect(Collectors.toList()))
 				.containsExactlyInAnyOrder("ROLE_MANAGE", "ROLE_CREATE", "ROLE_VIEW");
 	}
 
 	@Test
 	public void testThat7MappedAuthoritiesAreReturnedForDefaultMappingWithoutMappingScopes() throws Exception {
-
-		final ProviderRoleMapping providerRoleMapping = new ProviderRoleMapping();
+		ProviderRoleMapping providerRoleMapping = new ProviderRoleMapping();
 		providerRoleMapping.setMapOauthScopes(false);
 
-		final Set<String> scopes = new HashSet<>();
+		Set<String> scopes = new HashSet<>();
 		scopes.add("dataflow.manage");
 		scopes.add("dataflow.view");
 		scopes.add("dataflow.create");
 
-		final DefaultAuthoritiesMapper defaultAuthoritiesExtractor = new DefaultAuthoritiesMapper("uaa", false);
-
-		final Collection<? extends GrantedAuthority> authorities = defaultAuthoritiesExtractor.mapScopesToAuthorities("uaa", scopes, null);
+		DefaultAuthoritiesMapper defaultAuthoritiesExtractor = new DefaultAuthoritiesMapper("uaa", false);
+		Collection<? extends GrantedAuthority> authorities = defaultAuthoritiesExtractor.mapScopesToAuthorities("uaa",
+				scopes, null);
 
 		assertThat(authorities).hasSize(7);
-
 		assertThat(authorities.stream().map(authority -> authority.getAuthority()).collect(Collectors.toList()))
 				.containsExactlyInAnyOrder("ROLE_CREATE", "ROLE_DEPLOY", "ROLE_DESTROY", "ROLE_MANAGE", "ROLE_MODIFY",
 						"ROLE_SCHEDULE", "ROLE_VIEW");
@@ -183,25 +167,22 @@ public class DefaultAuthoritiesMapperTests {
 
 	@Test
 	public void testThat2MappedAuthoritiesAreReturnedForDefaultMapping() throws Exception {
-
-		final Set<String> scopes = new HashSet<>();
+		Set<String> scopes = new HashSet<>();
 		scopes.add("dataflow.view");
 		scopes.add("dataflow.create");
 
-		final DefaultAuthoritiesMapper defaultAuthoritiesExtractor = new DefaultAuthoritiesMapper("uaa", true);
-
-		final Collection<? extends GrantedAuthority> authorities = defaultAuthoritiesExtractor.mapScopesToAuthorities("uaa", scopes, null);
+		DefaultAuthoritiesMapper defaultAuthoritiesExtractor = new DefaultAuthoritiesMapper("uaa", true);
+		Collection<? extends GrantedAuthority> authorities = defaultAuthoritiesExtractor.mapScopesToAuthorities("uaa",
+				scopes, null);
 
 		assertThat(authorities).hasSize(2);
-
 		assertThat(authorities.stream().map(authority -> authority.getAuthority()).collect(Collectors.toList()))
 				.containsExactlyInAnyOrder("ROLE_CREATE", "ROLE_VIEW");
 	}
 
 	@Test
 	public void testThat7AuthoritiesAreReturnedAndOneOAuthScopeCoversMultipleServerRoles() throws Exception {
-		final Map<String, String> roleMappings = new HashMap<>();
-
+		Map<String, String> roleMappings = new HashMap<>();
 		roleMappings.put("ROLE_MANAGE", "foo-manage");
 		roleMappings.put("ROLE_VIEW", "foo-manage");
 		roleMappings.put("ROLE_DEPLOY", "foo-manage");
@@ -210,16 +191,15 @@ public class DefaultAuthoritiesMapperTests {
 		roleMappings.put("ROLE_SCHEDULE", "foo-manage");
 		roleMappings.put("ROLE_CREATE", "blubba-create");
 
-		final Set<String> scopes = new HashSet<>();
+		Set<String> scopes = new HashSet<>();
 		scopes.add("foo-manage");
 		scopes.add("blubba-create");
 
-		final DefaultAuthoritiesMapper defaultAuthoritiesExtractor = new DefaultAuthoritiesMapper("uaa", true, roleMappings);
-
-		final Collection<? extends GrantedAuthority> authorities = defaultAuthoritiesExtractor.mapScopesToAuthorities("uaa", scopes, null);
+		DefaultAuthoritiesMapper defaultAuthoritiesExtractor = new DefaultAuthoritiesMapper("uaa", true, roleMappings);
+		Collection<? extends GrantedAuthority> authorities = defaultAuthoritiesExtractor.mapScopesToAuthorities("uaa",
+				scopes, null);
 
 		assertThat(authorities).hasSize(7);
-
 		assertThat(authorities.stream().map(authority -> authority.getAuthority()).collect(Collectors.toList()))
 				.containsExactlyInAnyOrder("ROLE_CREATE", "ROLE_DEPLOY", "ROLE_DESTROY", "ROLE_MANAGE", "ROLE_MODIFY",
 						"ROLE_SCHEDULE", "ROLE_VIEW");
@@ -227,8 +207,7 @@ public class DefaultAuthoritiesMapperTests {
 
 	@Test
 	public void testThatUriStyleScopeRemovesLeadingPart() throws Exception {
-		final Map<String, String> roleMappings = new HashMap<>();
-
+		Map<String, String> roleMappings = new HashMap<>();
 		roleMappings.put("ROLE_MANAGE", "foo-manage");
 		roleMappings.put("ROLE_VIEW", "foo-manage");
 		roleMappings.put("ROLE_DEPLOY", "foo-manage");
@@ -237,16 +216,15 @@ public class DefaultAuthoritiesMapperTests {
 		roleMappings.put("ROLE_SCHEDULE", "foo-manage");
 		roleMappings.put("ROLE_CREATE", "blubba-create");
 
-		final Set<String> scopes = new HashSet<>();
+		Set<String> scopes = new HashSet<>();
 		scopes.add("api://foobar/foo-manage");
 		scopes.add("blubba-create");
 
-		final DefaultAuthoritiesMapper defaultAuthoritiesExtractor = new DefaultAuthoritiesMapper("uaa", true, roleMappings);
-
-		final Collection<? extends GrantedAuthority> authorities = defaultAuthoritiesExtractor.mapScopesToAuthorities("uaa", scopes, null);
+		DefaultAuthoritiesMapper defaultAuthoritiesExtractor = new DefaultAuthoritiesMapper("uaa", true, roleMappings);
+		Collection<? extends GrantedAuthority> authorities = defaultAuthoritiesExtractor.mapScopesToAuthorities("uaa",
+				scopes, null);
 
 		assertThat(authorities).hasSize(7);
-
 		assertThat(authorities.stream().map(authority -> authority.getAuthority()).collect(Collectors.toList()))
 				.containsExactlyInAnyOrder("ROLE_CREATE", "ROLE_DEPLOY", "ROLE_DESTROY", "ROLE_MANAGE", "ROLE_MODIFY",
 						"ROLE_SCHEDULE", "ROLE_VIEW");

--- a/spring-cloud-common-security-config-web/src/test/java/org/springframework/cloud/common/security/support/MappingJwtGrantedAuthoritiesConverterTests.java
+++ b/spring-cloud-common-security-config-web/src/test/java/org/springframework/cloud/common/security/support/MappingJwtGrantedAuthoritiesConverterTests.java
@@ -202,7 +202,7 @@ public class MappingJwtGrantedAuthoritiesConverterTests {
 
 	@Test
 	public void convertWhenTokenHasNoScopeAndNoScpAttributeThenTranslatesToNoAuthorities() {
-		Jwt jwt = jwt().claim("roles", Arrays.asList("message:read", "message:write")).build();
+		Jwt jwt = jwt().claim("xxx", Arrays.asList("message:read", "message:write")).build();
 
 		MappingJwtGrantedAuthoritiesConverter jwtGrantedAuthoritiesConverter = new MappingJwtGrantedAuthoritiesConverter();
 		Collection<GrantedAuthority> authorities = jwtGrantedAuthoritiesConverter.convert(jwt);
@@ -223,12 +223,12 @@ public class MappingJwtGrantedAuthoritiesConverterTests {
 	@Test
 	public void convertWhenTokenHasCustomClaimNameThenCustomClaimNameAttributeIsTranslatedToAuthorities() {
 		Jwt jwt = jwt()
-				.claim("roles", Arrays.asList("message:read", "message:write"))
+				.claim("xxx", Arrays.asList("message:read", "message:write"))
 				.claim("scope", "missive:read missive:write")
 				.build();
 
 		MappingJwtGrantedAuthoritiesConverter jwtGrantedAuthoritiesConverter = new MappingJwtGrantedAuthoritiesConverter();
-		jwtGrantedAuthoritiesConverter.setAuthoritiesClaimName("roles");
+		jwtGrantedAuthoritiesConverter.setAuthoritiesClaimName("xxx");
 		Collection<GrantedAuthority> authorities = jwtGrantedAuthoritiesConverter.convert(jwt);
 
 		assertThat(authorities).containsExactlyInAnyOrder(
@@ -259,5 +259,13 @@ public class MappingJwtGrantedAuthoritiesConverterTests {
 		Collection<GrantedAuthority> authorities = jwtGrantedAuthoritiesConverter.convert(jwt);
 
 		assertThat(authorities).isEmpty();
+	}
+
+	@Test
+	public void convertWhenTokenHasGroupClaims() {
+		Jwt jwt = jwt().claim("groups", Arrays.asList("role1")).build();
+		MappingJwtGrantedAuthoritiesConverter jwtGrantedAuthoritiesConverter = new MappingJwtGrantedAuthoritiesConverter();
+		Collection<GrantedAuthority> authorities = jwtGrantedAuthoritiesConverter.convert(jwt);
+		assertThat(authorities).containsExactlyInAnyOrder(new SimpleGrantedAuthority("SCOPE_role1"));
 	}
 }


### PR DESCRIPTION
- Similarly to mapping scopes to spring sec auth roles,
  we can now map claims like roles/groups.
- Boolean flag map-group-claims and under group-mappings.
- Fixes #86