### PR TITLE
feat: config to disable pathParts parsing

### DIFF
--- a/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/ProviderRoleMapping.java
+++ b/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/ProviderRoleMapping.java
@@ -37,6 +37,7 @@ public class ProviderRoleMapping {
 	private String rolePrefix = "ROLE_";
 	private String groupClaim = "roles";
 	private boolean mapOauthScopes = false;
+	private boolean parsePathParts = true;
 	private boolean mapGroupClaims = false;
 	private Map<String, String> roleMappings = new HashMap<>(0);
 	private Map<String, String> groupMappings = new HashMap<>(0);
@@ -54,6 +55,14 @@ public class ProviderRoleMapping {
 		Assert.notNull(roleMappings, "roleMappings must not be null.");
 		this.mapOauthScopes = mapOauthScopes;
 		this.roleMappings = roleMappings;
+	}
+
+	public boolean isParsePathParts() {
+		return parsePathParts;
+	}
+
+	public void setParsePathParts(boolean parsePathParts) {
+		this.parsePathParts = parsePathParts;
 	}
 
 	public boolean isMapOauthScopes() {

--- a/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/ProviderRoleMapping.java
+++ b/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/ProviderRoleMapping.java
@@ -37,7 +37,7 @@ public class ProviderRoleMapping {
 	private String rolePrefix = "ROLE_";
 	private String groupClaim = "roles";
 	private boolean mapOauthScopes = false;
-	private boolean parsePathParts = true;
+	private boolean parseOAuthPathParts = true;
 	private boolean mapGroupClaims = false;
 	private Map<String, String> roleMappings = new HashMap<>(0);
 	private Map<String, String> groupMappings = new HashMap<>(0);
@@ -57,12 +57,19 @@ public class ProviderRoleMapping {
 		this.roleMappings = roleMappings;
 	}
 
-	public boolean isParsePathParts() {
-		return parsePathParts;
+	public boolean isParseOAuthPathParts() {
+		return parseOAuthPathParts;
 	}
 
-	public void setParsePathParts(boolean parsePathParts) {
-		this.parsePathParts = parsePathParts;
+	/**
+	 * If set to false, OAuth scopes will not be treated as URIs during the role mapping and
+	 * the leading part is not going to be taken away if scope is something like
+	 * "api://dataflow-server/dataflow.create" resulting dataflow.create for example
+	 * 
+	 * @param parseOAuthPathParts if the scope should be treated as URI and to take away leading parts
+	 */
+	public void setParseOAuthPathParts(boolean parseOAuthPathParts) {
+		this.parseOAuthPathParts = parseOAuthPathParts;
 	}
 
 	public boolean isMapOauthScopes() {

--- a/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/ProviderRoleMapping.java
+++ b/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/ProviderRoleMapping.java
@@ -37,7 +37,7 @@ public class ProviderRoleMapping {
 	private String rolePrefix = "ROLE_";
 	private String groupClaim = "roles";
 	private boolean mapOauthScopes = false;
-	private boolean parseOAuthPathParts = true;
+	private boolean parseOauthScopePathParts = true;
 	private boolean mapGroupClaims = false;
 	private Map<String, String> roleMappings = new HashMap<>(0);
 	private Map<String, String> groupMappings = new HashMap<>(0);
@@ -57,19 +57,19 @@ public class ProviderRoleMapping {
 		this.roleMappings = roleMappings;
 	}
 
-	public boolean isParseOAuthPathParts() {
-		return parseOAuthPathParts;
+	public boolean isParseOauthScopePathParts() {
+		return parseOauthScopePathParts;
 	}
 
 	/**
-	 * If set to false, OAuth scopes will not be treated as URIs during the role mapping and
-	 * the leading part is not going to be taken away if scope is something like
-	 * "api://dataflow-server/dataflow.create" resulting dataflow.create for example
-	 * 
-	 * @param parseOAuthPathParts if the scope should be treated as URI and to take away leading parts
+	 * Sets whether or not to treat OAuth scopes as URIs during the role mapping.
+	 * When set to {@code true} the OAuth scope will be treated as a URI and the leading part will be ignored (eg. 'api://dataflow-server/dataflow.create' will result in 'dataflow.create').
+     * When set to {@code false} the OAuth scope will be used as-is. This is useful in cases where the scope is not a URI and contains '/' leading characters.
+	 *
+	 * @param parseOauthScopePathParts whether or not to treat OAuth scopes as URIs during the role mapping
 	 */
-	public void setParseOAuthPathParts(boolean parseOAuthPathParts) {
-		this.parseOAuthPathParts = parseOAuthPathParts;
+	public void setParseOauthScopePathParts(boolean parseOauthScopePathParts) {
+		this.parseOauthScopePathParts = parseOauthScopePathParts;
 	}
 
 	public boolean isMapOauthScopes() {

--- a/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/support/DefaultAuthoritiesMapper.java
+++ b/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/support/DefaultAuthoritiesMapper.java
@@ -148,7 +148,7 @@ public class DefaultAuthoritiesMapper implements AuthoritiesMapper {
 				for (Map.Entry<CoreSecurityRoles, String> roleMappingEngtry : roleMapping.convertRoleMappingKeysToCoreSecurityRoles().entrySet()) {
 					final CoreSecurityRoles role = roleMappingEngtry.getKey();
 					final String expectedOAuthScope = roleMappingEngtry.getValue();
-					Set<String> scopeList = roleMapping.isParseOAuthPathParts() ? pathParts(scopes) : scopes;
+					Set<String> scopeList = roleMapping.isParseOauthScopePathParts() ? pathParts(scopes) : scopes;
 					for (String scope : scopeList) {
 						if (scope.equalsIgnoreCase(expectedOAuthScope)) {
 							final SimpleGrantedAuthority oauthRoleAuthority = new SimpleGrantedAuthority(roleMapping.getRolePrefix() + role.getKey());

--- a/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/support/DefaultAuthoritiesMapper.java
+++ b/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/support/DefaultAuthoritiesMapper.java
@@ -148,7 +148,7 @@ public class DefaultAuthoritiesMapper implements AuthoritiesMapper {
 				for (Map.Entry<CoreSecurityRoles, String> roleMappingEngtry : roleMapping.convertRoleMappingKeysToCoreSecurityRoles().entrySet()) {
 					final CoreSecurityRoles role = roleMappingEngtry.getKey();
 					final String expectedOAuthScope = roleMappingEngtry.getValue();
-					Set<String> scopeList = roleMapping.isParsePathParts() ? pathParts(scopes) : scopes;
+					Set<String> scopeList = roleMapping.isParseOAuthPathParts() ? pathParts(scopes) : scopes;
 					for (String scope : scopeList) {
 						if (scope.equalsIgnoreCase(expectedOAuthScope)) {
 							final SimpleGrantedAuthority oauthRoleAuthority = new SimpleGrantedAuthority(roleMapping.getRolePrefix() + role.getKey());

--- a/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/support/DefaultAuthoritiesMapper.java
+++ b/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/support/DefaultAuthoritiesMapper.java
@@ -148,7 +148,8 @@ public class DefaultAuthoritiesMapper implements AuthoritiesMapper {
 				for (Map.Entry<CoreSecurityRoles, String> roleMappingEngtry : roleMapping.convertRoleMappingKeysToCoreSecurityRoles().entrySet()) {
 					final CoreSecurityRoles role = roleMappingEngtry.getKey();
 					final String expectedOAuthScope = roleMappingEngtry.getValue();
-					for (String scope : pathParts(scopes)) {
+					Set<String> scopeList = roleMapping.isParsePathParts() ? pathParts(scopes) : scopes;
+					for (String scope : scopeList) {
 						if (scope.equalsIgnoreCase(expectedOAuthScope)) {
 							final SimpleGrantedAuthority oauthRoleAuthority = new SimpleGrantedAuthority(roleMapping.getRolePrefix() + role.getKey());
 							rolesAsStrings.add(oauthRoleAuthority.getAuthority());

--- a/spring-cloud-common-security-config-web/src/test/java/org/springframework/cloud/common/security/support/DefaultAuthoritiesMapperTests.java
+++ b/spring-cloud-common-security-config-web/src/test/java/org/springframework/cloud/common/security/support/DefaultAuthoritiesMapperTests.java
@@ -147,9 +147,6 @@ public class DefaultAuthoritiesMapperTests {
 
 	@Test
 	public void testThat7MappedAuthoritiesAreReturnedForDefaultMappingWithoutMappingScopes() throws Exception {
-		ProviderRoleMapping providerRoleMapping = new ProviderRoleMapping();
-		providerRoleMapping.setMapOauthScopes(false);
-
 		Set<String> scopes = new HashSet<>();
 		scopes.add("dataflow.manage");
 		scopes.add("dataflow.view");
@@ -222,6 +219,41 @@ public class DefaultAuthoritiesMapperTests {
 
 		DefaultAuthoritiesMapper defaultAuthoritiesExtractor = new DefaultAuthoritiesMapper("uaa", true, roleMappings);
 		Collection<? extends GrantedAuthority> authorities = defaultAuthoritiesExtractor.mapScopesToAuthorities("uaa",
+				scopes, null);
+
+		assertThat(authorities).hasSize(7);
+		assertThat(authorities.stream().map(authority -> authority.getAuthority()).collect(Collectors.toList()))
+				.containsExactlyInAnyOrder("ROLE_CREATE", "ROLE_DEPLOY", "ROLE_DESTROY", "ROLE_MANAGE", "ROLE_MODIFY",
+						"ROLE_SCHEDULE", "ROLE_VIEW");
+	}
+
+	@Test
+	public void testThatUriStyleScopeParsingCanBeDisabled() throws Exception {
+		Map<String, String> roleMappings = new HashMap<>();
+		roleMappings.put("ROLE_MANAGE", "/ROLE/2000803042");
+		roleMappings.put("ROLE_VIEW", "/ROLE/2000803036");
+		roleMappings.put("ROLE_DEPLOY", "/ROLE/2000803039");
+		roleMappings.put("ROLE_DESTROY", "/ROLE/20008030340");
+		roleMappings.put("ROLE_MODIFY", "/ROLE/2000803037");
+		roleMappings.put("ROLE_SCHEDULE", "/ROLE/2000803038");
+		roleMappings.put("ROLE_CREATE", "/ROLE/2000803041");
+
+		ProviderRoleMapping providerRoleMapping = new ProviderRoleMapping();
+		providerRoleMapping.setMapOauthScopes(true);
+		providerRoleMapping.setParsePathParts(false);
+		providerRoleMapping.getRoleMappings().putAll(roleMappings);
+
+		Set<String> scopes = new HashSet<>();
+		scopes.add("/ROLE/2000803042");
+		scopes.add("/ROLE/2000803036");
+		scopes.add("/ROLE/2000803039");
+		scopes.add("/ROLE/20008030340");
+		scopes.add("/ROLE/2000803037");
+		scopes.add("/ROLE/2000803038");
+		scopes.add("/ROLE/2000803041");
+
+		DefaultAuthoritiesMapper defaultAuthoritiesMapper = new DefaultAuthoritiesMapper("uaa", providerRoleMapping);
+		Collection<? extends GrantedAuthority> authorities = defaultAuthoritiesMapper.mapScopesToAuthorities("uaa",
 				scopes, null);
 
 		assertThat(authorities).hasSize(7);

--- a/spring-cloud-common-security-config-web/src/test/java/org/springframework/cloud/common/security/support/DefaultAuthoritiesMapperTests.java
+++ b/spring-cloud-common-security-config-web/src/test/java/org/springframework/cloud/common/security/support/DefaultAuthoritiesMapperTests.java
@@ -240,7 +240,7 @@ public class DefaultAuthoritiesMapperTests {
 
 		ProviderRoleMapping providerRoleMapping = new ProviderRoleMapping();
 		providerRoleMapping.setMapOauthScopes(true);
-		providerRoleMapping.setParsePathParts(false);
+		providerRoleMapping.setParseOAuthPathParts(false);
 		providerRoleMapping.getRoleMappings().putAll(roleMappings);
 
 		Set<String> scopes = new HashSet<>();

--- a/spring-cloud-common-security-config-web/src/test/java/org/springframework/cloud/common/security/support/DefaultAuthoritiesMapperTests.java
+++ b/spring-cloud-common-security-config-web/src/test/java/org/springframework/cloud/common/security/support/DefaultAuthoritiesMapperTests.java
@@ -240,7 +240,7 @@ public class DefaultAuthoritiesMapperTests {
 
 		ProviderRoleMapping providerRoleMapping = new ProviderRoleMapping();
 		providerRoleMapping.setMapOauthScopes(true);
-		providerRoleMapping.setParseOAuthPathParts(false);
+		providerRoleMapping.setParseOauthScopePathParts(false);
 		providerRoleMapping.getRoleMappings().putAll(roleMappings);
 
 		Set<String> scopes = new HashSet<>();


### PR DESCRIPTION
Solves https://github.com/spring-cloud/spring-cloud-common-security-config/issues/94

With this PR you can disable the parsing of the pathParts by applying this configuration:

```yaml
    spring:
      cloud:
        dataflow:  
          security:
            authorization:
                user_login:
                  map-oauth-scopes: true
                  parse-oauth-scope-path-parts: false
                  role-mappings:
                    ROLE_CREATE: '/F///FUNC/2000803037///X'
```